### PR TITLE
Fix exit case when conda isn't installed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,17 +19,16 @@ then
 	echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
 	echo "No Conda installation detected, please install conda"
 	echo "https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#regular-installation"
-	exit 1
+else
+	# If conda environment exists, activate it. Otherwise create it
+	if ! (conda env list | grep ${MULE_ENV_NAME}) >> /dev/null
+	then
+		echo "Couldn't find environment, creating environment..."
+		conda env create -f MULE_environment.yml
+	fi
+
+	echo "Activating environment..."
+	conda activate ${MULE_ENV_NAME}
+
+	cd ${MULE_DIR}
 fi
-
-# If conda environment exists, activate it. Otherwise create it
-if ! (conda env list | grep ${MULE_ENV_NAME}) >> /dev/null
-then
-	echo "Couldn't find environment, creating environment..."
-	conda env create -f MULE_environment.yml
-fi
-
-echo "Activating environment..."
-conda activate ${MULE_ENV_NAME}
-
-cd ${MULE_DIR}


### PR DESCRIPTION
This PR fixes a bug (poorly written code) that caused `setup.sh` to close your bash window if you didn't have conda installed.