### PR TITLE
use pytest fixtures and create conftest.py

### DIFF
--- a/packs/tests/conftest.py
+++ b/packs/tests/conftest.py
@@ -1,4 +1,3 @@
-#from pathlib import Path
 import os
 import pytest
 
@@ -11,5 +10,5 @@ def data_dir(MULE_dir):
     return MULE_dir + '/packs/tests/data/'
 
 @pytest.fixture(scope="session")
-def ch3wd2_dir(data_dir):
+def wd2_3ch_bin(data_dir):
     return data_dir + 'three_channels_WD2.bin'

--- a/packs/tests/conftest.py
+++ b/packs/tests/conftest.py
@@ -1,0 +1,15 @@
+#from pathlib import Path
+import os
+import pytest
+
+@pytest.fixture(scope="session")
+def MULE_dir():
+    return str(os.environ['MULE_DIR'])
+
+@pytest.fixture(scope="session")
+def data_dir(MULE_dir):
+    return MULE_dir + '/packs/tests/data/'
+
+@pytest.fixture(scope="session")
+def ch3wd2_dir(data_dir):
+    return data_dir + 'three_channels_WD2.bin'

--- a/packs/tests/processing_test.py
+++ b/packs/tests/processing_test.py
@@ -36,14 +36,14 @@ def test_rwf_type_has_correct_shape(samples):
     assert x['rwf'].shape[0] == samples
 
 
-def test_header_components_read_as_expected(ch3wd2_dir):
+def test_header_components_read_as_expected(wd2_3ch_bin):
 
     evt_num   = 0
     tstamp    = 1998268
     smpls     = 1000
     smpl_prd  = 8
 
-    with open(ch3wd2_dir, 'rb') as f:
+    with open(wd2_3ch_bin, 'rb') as f:
         event_number, timestamp, samples, sampling_period = read_defaults_WD2(f, sys.byteorder)
 
     assert event_number        == evt_num
@@ -52,14 +52,14 @@ def test_header_components_read_as_expected(ch3wd2_dir):
     assert sampling_period     == smpl_prd
 
 
-def test_header_processed_correctly(ch3wd2_dir):
+def test_header_processed_correctly(wd2_3ch_bin):
 
     smpls     = 1000
     smpl_prd  = 8
     channels  = 3
     wdtype    = generate_wfdtype(channels, smpls) # 3 channels in this case
 
-    result = process_header(ch3wd2_dir)
+    result = process_header(wd2_3ch_bin)
 
     assert result[0] == wdtype
     assert result[1] == smpls
@@ -83,12 +83,12 @@ def test_header_works_when_data_malformed(data_dir):
 
 @mark.parametrize("function, error", [(process_header, NameError),
                                       (read_defaults_WD2, ValueError)])
-def test_endian_error_when_reading(function, error, ch3wd2_dir):
+def test_endian_error_when_reading(function, error, wd2_3ch_bin):
 
     byte_order = 'Big' # this will raise a ValueError
 
     with raises(error):
-        with open(ch3wd2_dir, 'rb') as f:
+        with open(wd2_3ch_bin, 'rb') as f:
             holder = function(f, byte_order)
 
 
@@ -103,7 +103,7 @@ def test_invalid_file_for_reading(data_dir):
     assert len(x) == 0
 
 
-def test_formatting_works(data_dir, ch3wd2_dir):
+def test_formatting_works(data_dir, wd2_3ch_bin):
 
     # collect relevant data from output
     check_file      = data_dir + 'three_channels_WD2.h5'
@@ -116,7 +116,7 @@ def test_formatting_works(data_dir, ch3wd2_dir):
 
     wdtype = types.generate_wfdtype(channels, samples)
 
-    with open(ch3wd2_dir, 'rb') as file:
+    with open(wd2_3ch_bin, 'rb') as file:
         # read in data
         data = read_binary(file, wdtype)
 

--- a/packs/tests/setup_test.py
+++ b/packs/tests/setup_test.py
@@ -1,22 +1,21 @@
-import os
 import subprocess
 import configparser
 
 from pytest                import mark
 from pytest                import raises
+from pytest                import fixture
 
 from packs.core.io         import read_config_file
 
 
 @mark.parametrize("pack", ["acq", "proc", "tests"])
-def test_executable_runs_successfully(pack):
+def test_executable_runs_successfully(pack, MULE_dir):
     '''
     This test is made to check if the current executable method for
     `bin/mule` to work as intended, accessing the relevant files when run.
     '''
-    bin_dir = str(os.environ['MULE_DIR'])
-                                                            # config will need to be improved
-    run_pack = ["python3", bin_dir + "/bin/mule", str(pack), "test_config"]
+                   # config will need to be improved
+    run_pack = ["python3", MULE_dir + "/bin/mule", str(pack), "test_config"]
 
     # ensure output is successful (no errors)
 
@@ -26,19 +25,17 @@ def test_executable_runs_successfully(pack):
     assert subprocess.run(run_pack).returncode == 0
 
 
-def test_incorrect_pack_returns_error():
-    bin_dir = str(os.environ['MULE_DIR'])
+def test_incorrect_pack_returns_error(MULE_dir):
 
     # give an incorrect pack
-    run_pack = ["python3", bin_dir + "/bin/mule", "donkey", "config"]
+    run_pack = ["python3", MULE_dir + "/bin/mule", "donkey", "config"]
 
     with raises(subprocess.CalledProcessError):
         subprocess.run(run_pack, check = True)
 
-def test_config_read_correctly():
+def test_config_read_correctly(data_dir):
 
-    MULE_dir = str(os.environ['MULE_DIR'])
-    file_path = MULE_dir + '/packs/tests/data/configs/test_config.conf'
+    file_path = data_dir + 'configs/test_config.conf'
 
     expected_dict = {'test_1': 'a string', 'test_2': 6.03, 'test_3': 5, 'test_4': True}
 
@@ -50,10 +47,9 @@ def test_config_read_correctly():
 @mark.parametrize("config, error", [('malformed_header.conf', configparser.MissingSectionHeaderError),
                                     ('empty_entry.conf', SyntaxError),
                                     ('incorrect_format.conf', configparser.ParsingError)])
-def test_malformed_config(config, error):
+def test_malformed_config(config, error, data_dir):
     # provides expected output when config file is malformed
-    MULE_dir = str(os.environ['MULE_DIR'])
-    file_path = MULE_dir + '/packs/tests/data/configs/' + config
+    file_path = data_dir + 'configs/' + config
 
     with raises(error):
         x = read_config_file(file_path)
@@ -63,10 +59,9 @@ def test_malformed_config(config, error):
                                     ('single_multi_chan.conf', RuntimeError)])
                                     # these will change to value errors when other
                                     # packs are implemented
-def test_processing_catches(config, error):
+def test_processing_catches(config, error, MULE_dir, data_dir):
 
-    MULE_dir = str(os.environ['MULE_DIR'])
-    config_path = MULE_dir + "/packs/tests/data/configs/" + config
+    config_path = data_dir + "configs/" + config
 
     run_pack = ["python3", MULE_dir + "/bin/mule", "proc", config_path]
 


### PR DESCRIPTION
Fix #27  . use pytest fixtures to restructure the various calling of directories in processing and setup tests; and create a conftest.py from which to manage fixtures