### PR TITLE
Update GHA runner

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -13,7 +13,7 @@ jobs:
         fail-fast: false
         matrix:
           python-version: [3.12]
-          platform: [ubuntu-20.04]
+          platform: [ubuntu-24.04]
       runs-on: ${{ matrix.platform }}
     
       steps:


### PR DESCRIPTION
As announced in [this blog post](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), the ubuntu-20.04 runner image has been retired on the 1st of April 2025. I've bumped the version to ubuntu-24.04 and all tests pass as expected.
