### PR TITLE
Include config file check

### DIFF
--- a/packs/core/io.py
+++ b/packs/core/io.py
@@ -1,3 +1,5 @@
+import os
+
 import pandas as pd
 
 import h5py
@@ -86,6 +88,10 @@ def read_config_file(file_path  :  str) -> dict:
     '''
     # setup config parser
     config = configparser.ConfigParser()
+
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(2, 'No such config file', file_path)
+        
 
     # read in arguments, require the required ones
     config.read(file_path)

--- a/packs/tests/io_test.py
+++ b/packs/tests/io_test.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+from pytest                        import mark
+from pytest                        import raises
+from pytest                        import warns
+
+from packs.core.io import read_config_file
+
+
+def test_missing_config(tmp_path, MULE_dir):
+    '''
+    Simple test ensuring that when config file path is wrong,
+    MULE spits out a `FileNotFoundError`
+    '''
+
+    config_path = f'{tmp_path}/false_config.conf'
+    
+    with raises(FileNotFoundError):
+        read_config_file(config_path)


### PR DESCRIPTION
As raised in #37, if no config file is provided MULE exits with a confusing error. This PR adds an appropriate error.